### PR TITLE
Fix for all qualities being "not supported"

### DIFF
--- a/cura-resources/definitions/Mark2_for_Ultimaker2.def.json
+++ b/cura-resources/definitions/Mark2_for_Ultimaker2.def.json
@@ -1,25 +1,21 @@
 {
-    "id": "Mark2_for_Ultimaker2",
     "version": 2,
     "name": "Mark2 for Ultimaker2",
     "inherits": "ultimaker2_plus",
     "metadata": {
-        "visible": true,
         "author": "TheUltimakerCommunity",
         "manufacturer": "Foehnsturm",
         "category": "Other",
         "quality_definition": "ultimaker2_plus",
         "weight": 1,
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker.png",
-        "platform": "ultimaker2_platform.obj",
         "platform_texture": "Mark2_for_Ultimaker2_backplate.png",
         "machine_extruder_trains":
         {
             "0": "Mark2_extruder1",
             "1": "Mark2_extruder2"
         },
-        "supported_actions": ["MachineSettingsAction", "UpgradeFirmware"]
+        "supported_actions": ["UpgradeFirmware"]
     },
     "overrides": {
         "machine_name": { "default_value": "Mark2_for_Ultimaker2" },

--- a/cura-resources/extruders/Mark2_extruder1.def.json
+++ b/cura-resources/extruders/Mark2_extruder1.def.json
@@ -4,6 +4,7 @@
     "name": "Extruder 1",
     "inherits": "fdmextruder",
     "metadata": {
+        "quality_definition": "ultimaker2_plus",
         "machine": "Mark2_for_Ultimaker2",
         "position": "0"
     },

--- a/cura-resources/extruders/Mark2_extruder2.def.json
+++ b/cura-resources/extruders/Mark2_extruder2.def.json
@@ -4,6 +4,7 @@
     "name": "Extruder 2",
     "inherits": "fdmextruder",
     "metadata": {
+        "quality_definition": "ultimaker2_plus",
         "machine": "Mark2_for_Ultimaker2",
         "position": "1"
     },

--- a/cura-resources/quality/mark2_for_ultimaker2/mk2forum2_global_Draft_Quality.inst.cfg
+++ b/cura-resources/quality/mark2_for_ultimaker2/mk2forum2_global_Draft_Quality.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 2
+name = Fast
+definition = ultimaker2_plus
+
+[metadata]
+type = quality
+quality_type = draft
+global_quality = True
+weight = -2
+setting_version = 4
+
+[values]
+layer_height = 0.2

--- a/cura-resources/quality/mark2_for_ultimaker2/mk2forum2_global_Fast_Quality.inst.cfg
+++ b/cura-resources/quality/mark2_for_ultimaker2/mk2forum2_global_Fast_Quality.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 2
+name = Normal
+definition = ultimaker2_plus
+
+[metadata]
+type = quality
+quality_type = fast
+global_quality = True
+weight = -1
+setting_version = 4
+
+[values]
+layer_height = 0.15

--- a/cura-resources/quality/mark2_for_ultimaker2/mk2forum2_global_High_Quality.inst.cfg
+++ b/cura-resources/quality/mark2_for_ultimaker2/mk2forum2_global_High_Quality.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 2
+name = Extra Fine
+definition = ultimaker2_plus
+
+[metadata]
+type = quality
+quality_type = high
+global_quality = True
+weight = 0
+setting_version = 4
+
+[values]
+layer_height = 0.06

--- a/cura-resources/quality/mark2_for_ultimaker2/mk2forum2_global_Normal_Quality.inst.cfg
+++ b/cura-resources/quality/mark2_for_ultimaker2/mk2forum2_global_Normal_Quality.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 2
+name = Fine
+definition = ultimaker2_plus
+
+[metadata]
+type = quality
+quality_type = normal
+global_quality = True
+weight = 0
+setting_version = 4
+
+[values]
+layer_height = 0.1

--- a/cura-resources/quality/mark2_for_ultimaker2/mk2forum2_global_Superdraft_Quality.inst.cfg
+++ b/cura-resources/quality/mark2_for_ultimaker2/mk2forum2_global_Superdraft_Quality.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 2
+name = Sprint
+definition = ultimaker2_plus
+
+[metadata]
+type = quality
+quality_type = superdraft
+global_quality = True
+weight = -4
+setting_version = 4
+
+[values]
+layer_height = 0.4

--- a/cura-resources/quality/mark2_for_ultimaker2/mk2forum2_global_Verydraft_Quality.inst.cfg
+++ b/cura-resources/quality/mark2_for_ultimaker2/mk2forum2_global_Verydraft_Quality.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 2
+name = Extra Fast
+definition = ultimaker2_plus
+
+[metadata]
+type = quality
+quality_type = verydraft
+global_quality = True
+weight = -3
+setting_version = 4
+
+[values]
+layer_height = 0.3


### PR DESCRIPTION
This PR fixes the problem where all qualities show as "Not supported" by adding a series of "global" profiles that are actually for the UM2+, but the UM2+ normally ignores these profiles because it is a single extrusion printer. The Mark2 uses the original set of UM2+ qualities for its extruders, but needs a set of "global" qualities for its global stack to go with the pre-existing extruder quality profiles.